### PR TITLE
update activiti-cloud-modeling to 7.0.28

### DIFF
--- a/charts/activiti-cloud-example-chart-modeling/requirements.yaml
+++ b/charts/activiti-cloud-example-chart-modeling/requirements.yaml
@@ -5,4 +5,4 @@ dependencies:
   version: "0.0.9"
 - name: "activiti-cloud-modeling"
   repository: "https://activiti.github.io/activiti-cloud-helm-charts/"
-  version: "7.0.24"
+  version: "7.0.28"


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed helm dependency: `activiti-cloud-modeling` to: `7.0.28`